### PR TITLE
Remove module declaration from types

### DIFF
--- a/lib/butter.d.ts
+++ b/lib/butter.d.ts
@@ -54,6 +54,4 @@ declare interface ButterStatic {
   content: ButterContentMethods;
 }
 
-declare module "buttercms" {
-  export = Butter;
-}
+export = Butter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buttercms",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ButterCMS API Client",
   "keywords": [
     "buttercms",


### PR DESCRIPTION
Fixes #16

My understanding of Typescript declaration arcanas is poor, however my understanding is that he module declaration in conjunction with import has triggered https://github.com/Microsoft/TypeScript-Handbook/blob/fa9e2be1024014fe923d44b1b69d315e8347e444/pages/Declaration%20Merging.md#module-augmentation which seems to have an issue with exports

I used the declaration template for functions from https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html which does not contain the module declaration

I have quickly tested this with a sample project and editing the types straight in node_modules. I can can repro the original issue and this solves it