### PR TITLE
Allow semver fix versions of axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "lib/butter.js",
   "types": "lib/butter.d.ts",
   "dependencies": {
-    "axios": "0.19.0"
+    "axios": "~0.19.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
The axios dependency shouldn't be limited to exactly 0.19.0.

This currently causes warnings during install with packages that require `axios` version `^0.19.0` or `0.19.2`, for example.