### PR TITLE
Bumped version in include statement to 1.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install buttercms --save
 Butter can also be included directly in HTML:
 
 ```html
-<script src="https://cdnjs.buttercms.com/buttercms-1.1.4.min.js"></script>
+<script src="https://cdnjs.buttercms.com/buttercms-1.2.8.min.js"></script>
 ```
 
 ## Overview


### PR DESCRIPTION
Noticed while looking at the npm package for the docs that the version in the <script> statement is 1.1.4, which is >3 years old. Bumped version in include statement in readme to 1.2.8, as that is the current version.