### PR TITLE
Updated TypeScript Import Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const butter = Butter('api_token_567abe');
 Using TypeScript:
 
 ```js
-import Butter = require('buttercms');
+import Butter from 'buttercms';
 const butter = Butter('api_token_567abe');
 ```
 


### PR DESCRIPTION
I believe the original import syntax shown in the TypeScript section was incorrect.