### PR TITLE
Update declaration file to include pages search functionality

### DIFF
--- a/lib/butter.d.ts
+++ b/lib/butter.d.ts
@@ -41,6 +41,7 @@ export namespace Butter {
       params?: any
     ): Promise<Response>;
     list(page_type: string, params?: any): Promise<Response>;
+    search(query: string, params?: any): Promise<Response>;
   }
 
   interface ContentMethods {


### PR DESCRIPTION
Projects with typescript get the error `Property 'search' does not exist on type 'PageMethods`