### PR TITLE
add: npm release GitHub action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+# This workflow will publish a package to npmjs.com when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on: push
+
+jobs:
+  publish-npm:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release)')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,7 +7,7 @@ on: push
 
 jobs:
   publish-npm:
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release)')
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(release)')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+## Release a new version
+
+All commit messages have to follow the [conventionalcommits.org](https://conventionalcommits.org) format specification.
+
+1. Make sure your are on the `master` branch.
+2. Make sure that you have committed everything and that your code is working.
+3. Run `npx standard-version`. This command updates the changelog with description of changes to your code since the last released version. It then increments the code version. All these changes are commited into the `master` branch.
+4. Push these changes to the remote repository and its `master` branch.
+5. A Github Action is triggered which automatically releases a new version to npmjs.com (https://www.npmjs.com/package/buttercms).
+
+For more detailed instructions read the [standard-version documentation](https://github.com/conventional-changelog/standard-version).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ All commit messages have to follow the [conventionalcommits.org](https://convent
 2. Make sure that you have committed everything and that your code is working.
 3. Run `npx standard-version`. This command updates the changelog with description of changes to your code since the last released version. It then increments the code version. All these changes are commited into the `master` branch.
 4. Push these changes to the remote repository and its `master` branch.
-5. A Github Action is triggered which automatically releases a new version to npmjs.com (https://www.npmjs.com/package/buttercms).
+5. A Github Action is triggered which automatically releases a new version to npmjs.com (https://www.npmjs.com/package/buttercms-js).
 
 For more detailed instructions read the [standard-version documentation](https://github.com/conventional-changelog/standard-version).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 All commit messages have to follow the [conventionalcommits.org](https://conventionalcommits.org) format specification.
 
-1. Make sure your are on the `master` branch.
+1. Make sure you are on the `master` branch.
 2. Make sure that you have committed everything and that your code is working.
 3. Run `npx standard-version`. This command updates the changelog with description of changes to your code since the last released version. It then increments the code version. All these changes are commited into the `master` branch.
 4. Push these changes to the remote repository and its `master` branch.


### PR DESCRIPTION
In order for this GitHub Action to work, an NPM auth token (`NPM_TOKEN`) has to be created in the npm repository and added to GitHub.