### PR TITLE
Chore/add release and publish actions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+# This workflow will publish a package to npmjs.com when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on: push
+
+jobs:
+  publish-npm:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release)')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,10 +13,10 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'chore(release)') 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-node@v3.7.0
         with:
-          node-version: 18
+          node-version: 18.16.1
           registry-url: https://registry.npmjs.org/
       - run: npm publish --access public
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,11 +3,14 @@
 
 name: Node.js Package
 
-on: push
-
+on:
+  push:
+    branches:
+      - master
+ 
 jobs:
   publish-npm:
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(release)')
+    if: contains(github.event.head_commit.message, 'chore(release)') 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
  
 jobs:
   publish-npm:
-    if: contains(github.event.head_commit.message, 'chore(release)') 
+    if: startsWith(github.event.head_commit.message, 'chore(release)') 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+# This workflow opens and updates a pull request with a new package version
+# based on code changes.
+
+# The pull request updates the version in package.json, updates the changelog
+# and creates release tags.
+
+# For more information, see https://github.com/marketplace/actions/release-please-action
+
+
+on:
+  push:
+    branches:
+      - master
+    
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+          pull-request-title-pattern: "chore(release): ${version}"
+          pull-request-header: ":robot: Merge this PR to release a new version"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ name: release-please
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: google-github-actions/release-please-action@v3.1.2
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3.1.2
         with:
           release-type: node
           package-name: release-please-action

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
   release-please:
     runs-on: ubuntu-22.04
     steps:
-      - uses: google-github-actions/release-please-action@v3.1.2
+      - uses: google-github-actions/release-please-action@v3.7.10
         with:
           release-type: node
           package-name: release-please-action

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ## Release and publish a new SDK version
 
-This SDK uses the [release-please](https://github.com/google-github-actions/release-please-action) automatic tool to prepare new versions for release.
+This SDK uses the [`release-please` GitHub Action](https://github.com/google-github-actions/release-please-action) to automate preparing new versions for release.
 
-When you are ready to release a new SDK version, make sure that all your code changes have been approved and merged into the `master` branch and that your code is working. The release-please tool generates changelog based on commit messages; these messages should follow the [Conventional Commits](https://conventionalcommits.org) specification in order for the changelog to reflect all code changes accurately. The changelog can, however, always be updated manually before the release.
+When you are ready to release a new SDK version, make sure that all your code changes have been approved and merged into the `master` branch and that your code is working. The `release-please` tool generates a changelog based on **commit messages; these messages should follow the [Conventional Commits](https://conventionalcommits.org) specification in order for the changelog to reflect all code changes accurately**. Otherwise, you would need to update the changelog manually before each release.
 
-The release-please tool opens and maintains a GitHub pull request with changes relevant to a new version release. Approve this pull request to release a new version of the SDK.
+The `release-please` action opens and maintains a GitHub pull request with changes relevant to a new version release. Approve this pull request to release a new version of the SDK.
 
 After the release, the new version is automatically published into the npm registry (see the package [here](https://www.npmjs.com/package/buttercms)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Release and publish a new SDK version
+
+This SDK uses the [release-please](https://github.com/google-github-actions/release-please-action) automatic tool to prepare new versions for release.
+
+When you are ready to release a new SDK version, make sure that all your code changes have been approved and merged into the `master` branch and that your code is working. The release-please tool generates changelog based on commit messages; these messages should follow the [Conventional Commits](https://conventionalcommits.org) specification in order for the changelog to reflect all code changes accurately. The changelog can, however, always be updated manually before the release.
+
+The release-please tool opens and maintains a GitHub pull request with changes relevant to a new version release. Approve this pull request to release a new version of the SDK.
+
+After the release, the new version is automatically published into the npm registry (see the package [here](https://www.npmjs.com/package/buttercms)).


### PR DESCRIPTION
❗ In order for the release tool to work, it is necessary to: 

- tag the latest release commit in the `master` branch with the tag `v1.2.12` (right now this is the latest SDK version).
- make sure that the field "Allow GitHub Actions to create and approve pull requests" in Settings > Actions > General is checked :heavy_check_mark:  ❗ 

❗ In order for the npm publish tool to work, an NPM auth token (`NPM_TOKEN`) has to be created in the npm repository and added to GitHub.❗ 

After these changes been aproved and merged into the `master` branch, the automatic release-please pull request will be opened next time when someone adds something releasable with a conventional commit message (i.e. with a prefix `fix:` or `feat:`).

This PR replaces my previous PR: https://github.com/ButterCMS/buttercms-js/pull/62 which can therefore be closed. 