### PR TITLE
Chore/change condition in publish action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
  
 jobs:
   publish-npm:
-    if: startsWith(github.event.head_commit.message, 'chore(release)') 
+    if: contains(github.event.head_commit.message, 'chore(release)') 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish-npm:
     if: contains(github.event.head_commit.message, 'chore(release)') 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-node@v3.7.0


### PR DESCRIPTION
Even though we discussed this condition before and settled on `startsWith`, I have realized that, at the moment, only `contains` is going to work. This is due to the fact that merging the `release-please` pull request that releases a new version technically merges two commits into the `master` branch (one with commit message `chore(release): ...` and the other `Merge ... into master`) and because these two commits are pushed into master at the same time, it is only the latter, i.e. newer commit that triggers the workflow, the one that only contains the phrase "chore(release)".

I am sorry that this detail slipped my attention due to the fact that we made this change directly in GitHub and I accidentally tested the workflow only with `contains`. 

Dealing with this issue differently would mean more substantial changes so for now I am settling for this fix.