### PR TITLE
Add status + scheduled to pages + blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Using ES6 or Typescript:
 
 ```js
 import Butter from "buttercms";
-const butter = Butter("api_token_567abe");
+const butter = Butter("your_api_token");
 ```
 
 Using CDN:
 
 ```html
 <script>
-  const butter = Butter("api_token_567abe");
+  const butter = Butter("your_api_token");
 </script>
 ```
 

--- a/lib/butter.d.ts
+++ b/lib/butter.d.ts
@@ -96,10 +96,11 @@ export namespace Butter {
     AuthorSlug extends string = string,
     PostSlug extends string = string
   > {
-    status: "published" | "draft";
+    status: "published" | "draft" | "scheduled";
     created: Date;
     updated: Date;
     published: Date;
+    scheduled: Date;
     title: string;
     slug: PostSlug;
     summary: string;
@@ -384,6 +385,8 @@ export namespace Butter {
     name: string;
     published: Date;
     updated: Date;
+    scheduled: Date;
+    status: "published" | "draft" | "scheduled";
     fields: PageModel;
   }
 


### PR DESCRIPTION
The only place I could see where the actual fields content is indicated in any way is the ts file - I'm guessing because of typing? 