### PR TITLE
Add missing locale param to Content and Page types

### DIFF
--- a/lib/butter.d.ts
+++ b/lib/butter.d.ts
@@ -355,6 +355,7 @@ export namespace Butter {
   interface PageRetrieveParams {
     preview?: 0 | 1;
     levels?: number;
+    locale?: string;
   }
 
   type PageListParams<PageModel extends object = object> =
@@ -364,6 +365,7 @@ export namespace Butter {
       order?: `${"-" | ""}${"published" | "updated"}`;
       page?: number;
       page_size?: number;
+      locale?: string;
     };
 
   interface PageSearchParams<PageType extends string = string> {
@@ -473,6 +475,7 @@ export namespace Butter {
       page?: number;
       page_size?: number;
       levels?: number;
+      locale?: string;
     };
 
   interface ContentResponse<ContentModels extends object = object> {


### PR DESCRIPTION
Added the missing `locale` parameter in butter.d.ts to support localized content retrieval.

This change ensures we can pass `locale` directly when retrieving pages and content, maintaining type safety and avoiding workarounds in code.