### PR TITLE
Exports types for resolution in ESM Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "exports": {
     ".": {
       "import": "./dist/butter.esm.js",
-      "require": "./dist/butter.umd.js"
+      "require": "./dist/butter.umd.js",
+      "types": "./lib/butter.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
While working with the buttercms NPM package in v2.3.0, I kept receiving the following Typescript error:

"Could not find a declaration file for module 'buttercms'. '/home/justi/projects/nv-web-platform/node_modules/buttercms/dist/butter.esm.js' implicitly has an 'any' type.

There are types at '/home/justi/projects/nv-web-platform/node_modules/buttercms/lib/butter.d.ts', but this result could not be resolved when respecting package.json "exports". The 'buttercms' library may need to update its package.json or typings."

From my research, I found an example at https://antfu.me/posts/publish-esm-and-cjs#tsup

It looks like when you split the exports between cjs and esm, you also need to export the types in package.json for the typings to apply to both exports.

I tested this by patching the package.json in my local node_modules and it fixes the issue.

Since I already did the research and it's a one-line fix, I figured I'd just submit a PR instead of an issue. I hope that's alright!