### PR TITLE
[BCMS-926] Fixes timeout handling for wider compatibility

### DIFF
--- a/lib/butter.js
+++ b/lib/butter.js
@@ -46,12 +46,8 @@ export default function (apiToken, options = {}) {
     if (!apiToken) {
         throw 'ButterCMS API token not set';
     }
-
-    if (!(this instanceof Butter)) {
-        return new Butter(apiToken, options);
-    }
-
-    return Butter
+    
+    return new Butter(apiToken, options);
 };
 
 /**

--- a/lib/useButter.js
+++ b/lib/useButter.js
@@ -78,13 +78,14 @@ export default function useButter(type, butterConfig) {
         try {
             // use static abortSignal timeout functionality to relay a cancelation 
             // when timeout is reached
-            // if AbortSignal.timeout doestn't exist (React Native), use a regular timeotu
+            // if AbortSignal.timeout doesn't exist (React Native/Node.js), use a regular timeout
+            let timeoutId;
             const timeoutSignal = AbortSignal.timeout 
                 ? AbortSignal.timeout(config.timeout)
-                : setTimeout(
+                : (timeoutId = setTimeout(
                     () => abortOnTimeout(config.timeout),
                     config.timeout
-                )
+                ))
 
             const response = await fetch(
                 `${apiEndpoint}?${new URLSearchParams(params)}`,
@@ -100,10 +101,10 @@ export default function useButter(type, butterConfig) {
                 }
             );
 
-            if (!AbortSignal.timeout) {
-                // if we are running on a regular timout, 
+            if (!AbortSignal.timeout && timeoutId) {
+                // if we are running on a regular timeout, 
                 // clear it after its use
-                clearTimeout(timeoutSignal)
+                clearTimeout(timeoutId)
             }
 
             cleanup();


### PR DESCRIPTION
It re-applies https://github.com/ButterCMS/buttercms-js/pull/124 with proper conventions for commit messages (which allows automatic publish to run).